### PR TITLE
Use latest wordpress version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:5.1.1-php7.3-apache
+    image: wordpress:5.5.1-php7.3-apache
     ports:
       - "8000:80"
     restart: always


### PR DESCRIPTION
Thanks for the nice blog post and the repo for getting started with wordpress theme development on docker. As this repo seemed a bit outdated, I wanted to update the docker-compose file to the lastet wordpress version.