### PR TITLE
add 'z' option to bind mounts to set required SELinux context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
     working_dir: /var/www/html
     volumes:
-      - ./wp-content:/var/www/html/wp-content
-      - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
+      - ./wp-content:/var/www/html/wp-content:z
+      - ./uploads.ini:/usr/local/etc/php/conf.d/uploads.ini:z
 volumes:
   db_data:


### PR DESCRIPTION
Bind mounts won't work on systems where SELinux is running. The :z option automatically sets the "container_file_t" context, which solves the issue.